### PR TITLE
[ci skip] removing user @goanpeca

### DIFF
--- a/README.md
+++ b/README.md
@@ -144,6 +144,5 @@ Feedstock Maintainers
 =====================
 
 * [@andreabassi78](https://github.com/andreabassi78/)
-* [@goanpeca](https://github.com/goanpeca/)
 * [@jaimergp](https://github.com/jaimergp/)
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -53,5 +53,4 @@ about:
 extra:
   recipe-maintainers:
     - andreabassi78
-    - goanpeca
     - jaimergp


### PR DESCRIPTION
Manually removing @goanpeca from the maintainers list because the conda-forge-admin bot has not processed the request.

Closes #6